### PR TITLE
Update SKNP's url

### DIFF
--- a/packages/site/src/assets/data/manual-sponsors.json
+++ b/packages/site/src/assets/data/manual-sponsors.json
@@ -42,7 +42,7 @@
     "id": "Sknp1006",
     "name": "SKNP",
     "avatar": "https://cdn.jsdelivr.net/gh/Sknp1006/cdn@master/img/albums/arknights_Skadi/024.png",
-    "url": "https://sknplz.xyz/",
+    "url": "https://sknp.top/",
     "total": 312,
     "children": [
       {


### PR DESCRIPTION
### Description

更新了SKNP的博客链接，原先的sknplz.xyz将弃用，新的链接为sknp.top

